### PR TITLE
Fix android Base64 decoding

### DIFF
--- a/android/src/main/java/com/passkit/PasskitModule.kt
+++ b/android/src/main/java/com/passkit/PasskitModule.kt
@@ -94,7 +94,7 @@ class PasskitModule(
     @ReactMethod
     fun addPass(base64encodedPass: String, promise: Promise){
         reactContext.currentActivity?.let {
-          val pass = Base64.decode(base64encodedPass, Base64.DEFAULT).toString()
+          val pass = Base64.decode(base64encodedPass, Base64.DEFAULT).toString(Charsets.UTF_8)
           walletClient?.savePasses(pass, it, addToGoogleWalletRequestCode)
           promise.resolve(true)
           return


### PR DESCRIPTION
`.toString()` requires a charset to be be specified else it just [returns the object ID](https://stackoverflow.com/a/66616075/280980).

Without this fix the `addPass` method will always result in `INVALID_JSON`.