### PR TITLE
fix: New Architecture compatibility for Android and Expo iOS

### DIFF
--- a/android/src/main/java/com/passkit/PasskitModule.kt
+++ b/android/src/main/java/com/passkit/PasskitModule.kt
@@ -19,7 +19,7 @@ class PasskitModule(
     override fun getName() = "PasskitModule"
 
     private val activityEventListener = object : BaseActivityEventListener() {
-      override fun onActivityResult(activity: Activity?, requestCode: Int, resultCode: Int, intent: Intent?) {
+      override fun onActivityResult(activity: Activity, requestCode: Int, resultCode: Int, data: Intent?) {
         if (requestCode == addToGoogleWalletRequestCode) {
           when (resultCode) {
             Activity.RESULT_OK -> {
@@ -34,7 +34,7 @@ class PasskitModule(
               })
             }
 
-            PayClient.SavePassesResult.SAVE_ERROR -> intent?.let { intentData ->
+            PayClient.SavePassesResult.SAVE_ERROR -> data?.let { intentData ->
               val errorMessage = intentData.getStringExtra(PayClient.EXTRA_API_ERROR_MESSAGE)
 
               sendReactEvent(reactContext, "addPassResult", Arguments.createMap().apply {

--- a/react-native-passkit.podspec
+++ b/react-native-passkit.podspec
@@ -22,12 +22,18 @@ Pod::Spec.new do |s|
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
     s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
     s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/ReactNativeDependencies\"",
         "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
+    # When RCT_USE_RN_DEP=1 (Expo/default) React Native uses prebuilt deps and does not add
+    # RCT-Folly to Podfile. Use ReactNativeDependencies instead so pod install succeeds.
+    if ENV['RCT_USE_RN_DEP'] == '1'
+      s.dependency "ReactNativeDependencies"
+    else
+      s.dependency "RCT-Folly"
+    end
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
# 🚀 Fix: New Architecture compatibility for Android & Expo (iOS)

### 📝 Description
This PR addresses critical build and runtime issues when using the library with **React Native New Architecture** (TurboModules), specifically in **Expo** environments.

---

### 🛠 Changes

#### **Android (Kotlin)**
* **Refined `onActivityResult` signature:** Updated the method override to match `BaseActivityEventListener` requirements.
* **Fix parameter naming:** Renamed `intent` to `data` and ensured the `SAVE_ERROR` case correctly references the intent data.
* **Nullability adjustment:** Adjusted `Activity` nullability for compatibility with recent RN/Kotlin versions.

#### **iOS (Podspec)**
* **Enhanced Header Search Paths:** Added `$(PODS_ROOT)/RCT-Folly` and `$(PODS_ROOT)/ReactNativeDependencies`.
* **Expo Compatibility:** Added a conditional check for `RCT_USE_RN_DEP=1`:
    * If enabled, it now depends on `ReactNativeDependencies`.
    * Otherwise, it falls back to the standard `RCT-Folly`.
* **Compiler Flags:** Ensured `c++17` and `FOLLY` flags are applied.

---

### ❓ Why this is needed
Currently, the library fails to compile in projects using **Expo SDK** with the New Architecture enabled because the Podspec doesn't account for how Expo handles prebuilt dependencies.

### ✅ How to test
1. Enable New Architecture (`RCT_NEW_ARCH_ENABLED=1`).
2. Install this branch: 
   `npm install SusulAdam/react-native-passkit#fix/expo-new-arch-android-callback`
3. Run `pod install` (iOS) or `./gradlew assembleDebug` (Android).